### PR TITLE
added responsive support for mobile version

### DIFF
--- a/packages/editor-common/package.json
+++ b/packages/editor-common/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@agorapp-dao/content-common": "workspace:^",
     "@monaco-editor/loader": "^1.3.3",
+    "@react-hook/window-size": "^3.1.1",
     "monaco-editor": "*",
     "react-full-screen": "^1.1.1",
     "react-markdown": "^8.0.7",

--- a/packages/editor-common/src/Editor/Editor.styled.ts
+++ b/packages/editor-common/src/Editor/Editor.styled.ts
@@ -27,6 +27,17 @@ export const Section = styled.div`
   border-right: ${p => p.theme.panelSeparator};
 `;
 
+export const OverlaySection = styled.div`
+  position: absolute;
+  top: 0;
+  left: 48px;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  display: flex;
+  background-color: ${p => p.theme.background};
+`;
+
 export const RightPane = styled.div`
   display: flex;
   flex-direction: column;

--- a/packages/editor-common/src/Editor/LessonHeader/LessonHeader.styled.ts
+++ b/packages/editor-common/src/Editor/LessonHeader/LessonHeader.styled.ts
@@ -2,8 +2,16 @@ import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   position: relative;
-  padding: 0.2rem 1rem;
+  padding: 0.2rem 0 0.2rem 1rem;
   border-bottom: ${p => p.theme.panelSeparator};
+  display: flex;
+  flex-direction: row;
+`;
+
+export const IconWrapper = styled.div`
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: end;
 `;
 
 export const ButtonContent = styled.div`

--- a/packages/editor-common/src/Editor/LessonHeader/LessonHeader.tsx
+++ b/packages/editor-common/src/Editor/LessonHeader/LessonHeader.tsx
@@ -1,13 +1,15 @@
 import * as S from './LessonHeader.styled';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Button } from '@mui/material';
+import { Button, IconButton } from '@mui/material';
 import React from 'react';
 import { styled } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
 
 type TProps = {
   handleClick: () => void;
   title: string;
+  handleClose?: () => void;
 };
 
 // TODO - solve 'any'
@@ -15,7 +17,7 @@ const LessonButton = styled((props: any) => <Button {...props} />)(({ theme }) =
   textTransform: 'none',
 }));
 
-export const LessonHeader: React.FC<TProps> = ({ handleClick, title }) => {
+export const LessonHeader: React.FC<TProps> = ({ handleClick, title, handleClose }) => {
   return (
     <S.Wrapper>
       <LessonButton variant="text" onClick={handleClick}>
@@ -25,6 +27,13 @@ export const LessonHeader: React.FC<TProps> = ({ handleClick, title }) => {
           <ExpandMoreIcon />
         </S.ButtonContent>
       </LessonButton>
+      {handleClose && (
+        <S.IconWrapper>
+          <IconButton aria-label="close" onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
+        </S.IconWrapper>
+      )}
     </S.Wrapper>
   );
 };

--- a/packages/editor-common/src/Editor/SectionTabs/SectionTabs.tsx
+++ b/packages/editor-common/src/Editor/SectionTabs/SectionTabs.tsx
@@ -61,7 +61,11 @@ export const SectionTabs = () => {
           <Tabs
             orientation="vertical"
             variant="scrollable"
-            value={currentSection}
+            value={
+              !mobile && currentSection === EEditorSectionType.CODE
+                ? EEditorSectionType.LESSON
+                : currentSection
+            }
             onChange={changeSection}
             aria-label="Navigation menu"
             sx={{ borderRight: 0 }}

--- a/packages/editor-common/src/Editor/SectionTabs/SectionTabs.tsx
+++ b/packages/editor-common/src/Editor/SectionTabs/SectionTabs.tsx
@@ -1,15 +1,16 @@
 import { Box, Icon, IconButton, Tab, Tabs } from '@mui/material';
 import React, { useContext, useState } from 'react';
 import ImportContactsIcon from '@mui/icons-material/ImportContacts';
-import BackupIcon from '@mui/icons-material/Backup';
 import { styled } from '@mui/material/styles';
 import * as S from './SectionTabs.styled';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
+import CodeIcon from '@mui/icons-material/Code';
 import { EEditorSectionType } from '../../constants';
 import { EditorContext } from '../EditorContext';
 import { AgorAppIcon } from '../../constants/assets';
 import { SettingsDialog } from '../SettingsDialog/SettingsDialog';
 import { AuthorDialog } from '../../components/AuthorDialog/AuthorDialog';
+import { useMobile } from '../../hooks/useMobile';
 
 interface StyledTabProps {
   icon?: string | React.ReactElement;
@@ -38,6 +39,7 @@ const AntTab = styled((props: StyledTabProps) => <Tab disableRipple {...props} /
 }));
 
 export const SectionTabs = () => {
+  const { mobile } = useMobile();
   const { currentSection, setCurrentSection } = useContext(EditorContext);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [authorDialogOpen, setAuthorDialogOpen] = useState(false);
@@ -65,8 +67,7 @@ export const SectionTabs = () => {
             sx={{ borderRight: 0 }}
           >
             <AntTab icon={<ImportContactsIcon />} value={EEditorSectionType.LESSON} />
-            {/*<AntTab icon={<FolderOpenIcon/>} value={EEditorSectionType.TREE}/>*/}
-            <AntTab icon={<BackupIcon />} value={EEditorSectionType.SHARE} />
+            {mobile && <AntTab icon={<CodeIcon />} value={EEditorSectionType.CODE} />}
           </Tabs>
         </Box>
       </S.Tabs>

--- a/packages/editor-common/src/constants.ts
+++ b/packages/editor-common/src/constants.ts
@@ -1,5 +1,7 @@
 export enum EEditorSectionType {
   LESSON = 'lesson',
   SHARE = 'share',
-  TREE = 'tree',
+  CODE = 'code',
 }
+
+export const MOBILE_TRIGGER_WIDTH = 768;

--- a/packages/editor-common/src/hooks/useMobile.ts
+++ b/packages/editor-common/src/hooks/useMobile.ts
@@ -1,0 +1,10 @@
+import { useWindowWidth } from '@react-hook/window-size';
+import { MOBILE_TRIGGER_WIDTH } from '../constants';
+
+export const useMobile = () => {
+  const width = useWindowWidth();
+
+  const mobile = width < MOBILE_TRIGGER_WIDTH;
+
+  return { mobile };
+};

--- a/packages/editor-common/src/hooks/useMobile.ts
+++ b/packages/editor-common/src/hooks/useMobile.ts
@@ -1,10 +1,14 @@
 import { useWindowWidth } from '@react-hook/window-size';
 import { MOBILE_TRIGGER_WIDTH } from '../constants';
+import { useEffect, useState } from 'react';
 
 export const useMobile = () => {
   const width = useWindowWidth();
+  const [mobile, setMobile] = useState(false);
 
-  const mobile = width < MOBILE_TRIGGER_WIDTH;
+  useEffect(() => {
+    setMobile(width < MOBILE_TRIGGER_WIDTH);
+  }, [width]);
 
   return { mobile };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,106 +21,6 @@ importers:
         specifier: 4.9.5
         version: 4.9.5
 
-  agorapp-editor-lite:
-    dependencies:
-      '@agorapp-dao/content-common':
-        specifier: workspace:^
-        version: link:../packages/content-common
-      '@agorapp-dao/content-motoko-tutorial':
-        specifier: workspace:^
-        version: link:../packages/content-motoko-tutorial
-      '@agorapp-dao/editor-common':
-        specifier: workspace:^
-        version: link:../packages/editor-common
-      '@agorapp-dao/editor-lang-motoko':
-        specifier: workspace:^
-        version: link:../packages/editor-lang-motoko
-      '@emotion/core':
-        specifier: ^11.0.0
-        version: 11.0.0
-      '@emotion/react':
-        specifier: ^11.11.0
-        version: 11.11.0(@types/react@18.0.28)(react@18.2.0)
-      '@emotion/styled':
-        specifier: ^11.11.0
-        version: 11.11.0(@emotion/react@11.11.0)(@types/react@18.0.28)(react@18.2.0)
-      '@emotion/stylis':
-        specifier: ^0.8.5
-        version: 0.8.5
-      '@fontsource/roboto':
-        specifier: ^4.5.8
-        version: 4.5.8
-      '@mui/icons-material':
-        specifier: ^5.11.16
-        version: 5.11.16(@mui/material@5.12.3)(@types/react@18.0.28)(react@18.2.0)
-      '@mui/lab':
-        specifier: ^5.0.0-alpha.130
-        version: 5.0.0-alpha.130(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@mui/material@5.12.3)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@mui/material':
-        specifier: ^5.12.3
-        version: 5.12.3(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@mui/styled-engine-sc':
-        specifier: ^5.12.0
-        version: 5.12.0(@types/styled-components@5.1.26)(styled-components@6.0.0-rc.1)
-      '@types/node':
-        specifier: 18.14.6
-        version: 18.14.6
-      '@types/react':
-        specifier: 18.0.28
-        version: 18.0.28
-      '@types/react-dom':
-        specifier: 18.0.11
-        version: 18.0.11
-      eslint:
-        specifier: 8.35.0
-        version: 8.35.0
-      eslint-config-next:
-        specifier: 13.4.9
-        version: 13.4.9(eslint@8.35.0)(typescript@4.9.5)
-      next:
-        specifier: 13.4.9
-        version: 13.4.9(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
-      polished:
-        specifier: ^4.2.2
-        version: 4.2.2
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
-      styled-components:
-        specifier: ^6.0.0-rc.1
-        version: 6.0.0-rc.1(react-dom@18.2.0)(react@18.2.0)
-      swr:
-        specifier: ^2.1.5
-        version: 2.1.5(react@18.2.0)
-      typescript:
-        specifier: 4.9.5
-        version: 4.9.5
-    devDependencies:
-      '@testing-library/jest-dom':
-        specifier: ^5.16.5
-        version: 5.16.5
-      '@testing-library/react':
-        specifier: ^14.0.0
-        version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
-      '@types/jest':
-        specifier: ^29.5.2
-        version: 29.5.2
-      '@types/styled-components':
-        specifier: ^5.1.26
-        version: 5.1.26
-      eslint-config-prettier:
-        specifier: ^8.8.0
-        version: 8.8.0(eslint@8.35.0)
-      jest:
-        specifier: ^29.5.0
-        version: 29.5.0(@types/node@18.14.6)
-      jest-environment-jsdom:
-        specifier: ^29.5.0
-        version: 29.5.0
-
   motoko-editor:
     dependencies:
       '@agorapp-dao/content-common':
@@ -233,8 +133,6 @@ importers:
         specifier: workspace:^
         version: link:../content-common
 
-  packages/content-solidity-sample: {}
-
   packages/editor-common:
     dependencies:
       '@agorapp-dao/content-common':
@@ -264,6 +162,9 @@ importers:
       '@mui/material':
         specifier: ^5.12.3
         version: 5.12.3(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@react-hook/window-size':
+        specifier: ^3.1.1
+        version: 3.1.1(react@18.2.0)
       '@types/react':
         specifier: 18.0.28
         version: 18.0.28
@@ -275,7 +176,7 @@ importers:
         version: 0.36.1
       next:
         specifier: ^13.4.9
-        version: 13.4.9(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.9(@babel/core@7.22.8)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -366,15 +267,6 @@ importers:
         specifier: ^29.5.0
         version: 29.5.0(@types/node@18.14.6)
 
-  packages/editor-lang-solidity:
-    dependencies:
-      '@agorapp-dao/editor-common':
-        specifier: workspace:^
-        version: link:../editor-common
-      monaco-editor:
-        specifier: '*'
-        version: 0.36.1
-
 packages:
 
   /@adobe/css-tools@4.2.0:
@@ -443,6 +335,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.22.8:
     resolution: {integrity: sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==}
@@ -510,6 +403,7 @@ packages:
       browserslist: 4.21.9
       lru-cache: 5.1.1
       semver: 6.3.0
+    dev: true
 
   /@babel/helper-compilation-targets@7.22.5(@babel/core@7.22.8):
     resolution: {integrity: sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==}
@@ -729,6 +623,7 @@ packages:
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.22.6:
     resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
@@ -2786,6 +2681,51 @@ packages:
 
   /@popperjs/core@2.11.8:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+    dev: false
+
+  /@react-hook/debounce@3.0.0(react@18.2.0):
+    resolution: {integrity: sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@react-hook/latest': 1.0.3(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@react-hook/event@1.2.6(react@18.2.0):
+    resolution: {integrity: sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /@react-hook/latest@1.0.3(react@18.2.0):
+    resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /@react-hook/throttle@2.2.0(react@18.2.0):
+    resolution: {integrity: sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@react-hook/latest': 1.0.3(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@react-hook/window-size@3.1.1(react@18.2.0):
+    resolution: {integrity: sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@react-hook/debounce': 3.0.0(react@18.2.0)
+      '@react-hook/event': 1.2.6(react@18.2.0)
+      '@react-hook/throttle': 2.2.0(react@18.2.0)
+      react: 18.2.0
     dev: false
 
   /@rushstack/eslint-patch@1.3.2:
@@ -6232,49 +6172,6 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  /next@13.4.9(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-vtefFm/BWIi/eWOqf1GsmKG3cjKw1k3LjuefKRcL3iiLl3zWzFdPG3as6xtxrGO6gwTzzaO1ktL4oiHt/uvTjA==}
-    engines: {node: '>=16.8.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      fibers: '>= 3.1.0'
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      fibers:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 13.4.9
-      '@swc/helpers': 0.5.1
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001514
-      postcss: 8.4.14
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.22.5)(react@18.2.0)
-      watchpack: 2.4.0
-      zod: 3.21.4
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 13.4.9
-      '@next/swc-darwin-x64': 13.4.9
-      '@next/swc-linux-arm64-gnu': 13.4.9
-      '@next/swc-linux-arm64-musl': 13.4.9
-      '@next/swc-linux-x64-gnu': 13.4.9
-      '@next/swc-linux-x64-musl': 13.4.9
-      '@next/swc-win32-arm64-msvc': 13.4.9
-      '@next/swc-win32-ia32-msvc': 13.4.9
-      '@next/swc-win32-x64-msvc': 13.4.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
-
   /next@13.4.9(@babel/core@7.22.8)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-vtefFm/BWIi/eWOqf1GsmKG3cjKw1k3LjuefKRcL3iiLl3zWzFdPG3as6xtxrGO6gwTzzaO1ktL4oiHt/uvTjA==}
     engines: {node: '>=16.8.0'}
@@ -7263,24 +7160,6 @@ packages:
       tslib: 2.6.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /styled-jsx@5.1.1(@babel/core@7.22.5)(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.5
-      client-only: 0.0.1
-      react: 18.2.0
     dev: false
 
   /styled-jsx@5.1.1(@babel/core@7.22.8)(react@18.2.0):


### PR DESCRIPTION
- hide theory when resolution is less than 768px
- show code tab btn in left sidebar to allow switch between theory and code

Preview:
<img width="496" alt="image" src="https://github.com/agorapp-dao/motoko-editor/assets/12710685/c89a83ad-f35f-412a-9d0a-2422bac4e3a0">
